### PR TITLE
monitoring: fix listening port

### DIFF
--- a/src/monitoring.c
+++ b/src/monitoring.c
@@ -81,7 +81,7 @@ struct monitoring* monitoring_init(const struct config *config)
 	setsockopt(monitoring->sockfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 
 	server_addr.sin_family = AF_INET;
-	server_addr.sin_port = port;
+	server_addr.sin_port = htons(port);
 	server_addr.sin_addr.s_addr = inet_addr(address);
 
 	ret = bind(monitoring->sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr));

--- a/tests/monitoring_client.c
+++ b/tests/monitoring_client.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
 	struct sockaddr_in server_addr;
 	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sin_family = AF_INET;
-	server_addr.sin_port = 2958;
+	server_addr.sin_port = htons(2958);
 	server_addr.sin_addr.s_addr = inet_addr("0.0.0.0");
 	
 	//Initiate a connection to the server


### PR DESCRIPTION
Config:

```
monitoring=true
socket-address=0.0.0.0
socket-port=2958
oscillator=dummy
gnss-device-tty=/dev/ttyS4
gnss-receiver-reconfigure=true
ptp-clock=/dev/ptp2
```

Before:

```
ss -lnp | grep -i osci
tcp     LISTEN   0        1                                             0.0.0.0:36363                                              0.0.0.0:*                     users:(("oscillatord",pid=68329,fd=3))                                         
```

After:

```
ss -lnp | grep -i osci
tcp     LISTEN   0        1                                             0.0.0.0:2958                                               0.0.0.0:*                     users:(("oscillatord",pid=144162,fd=3))                                        
```