### PR TITLE
[oscillators] get_temp consistency

### DIFF
--- a/src/oscillators/dummy_oscillator.c
+++ b/src/oscillators/dummy_oscillator.c
@@ -48,12 +48,11 @@ static int dummy_oscillator_save(struct oscillator *oscillator)
 	return 0;
 }
 
-static int dummy_oscillator_get_temp(struct oscillator *oscillator,
-		uint16_t *temp)
+static int dummy_oscillator_get_temp(struct oscillator *oscillator, double *temp)
 {
 	*temp = (rand() % (55 - 10)) + 10;
 
-	log_info("%s(%p, %u)", __func__, oscillator, *temp);
+	log_info("%s(%p, %g)", __func__, oscillator, *temp);
 
 	return 0;
 }

--- a/src/oscillators/sim_oscillator.c
+++ b/src/oscillators/sim_oscillator.c
@@ -80,12 +80,11 @@ static int sim_oscillator_save(struct oscillator *oscillator)
 	return -ENOSYS;
 }
 
-static int sim_oscillator_get_temp(struct oscillator *oscillator,
-		uint16_t *temp)
+static int sim_oscillator_get_temp(struct oscillator *oscillator, double *temp)
 {
 	*temp = (rand() % (55 - 10)) + 10;
 
-	log_info("%s(%p, %u)", __func__, oscillator, *temp);
+	log_info("%s(%p, %g)", __func__, oscillator, *temp);
 
 	return 0;
 }


### PR DESCRIPTION
I think the "get_temp" function definition should be consistent across all oscillators implementations, shouldn't it?

`oscillator.c` function definition is:

```
int oscillator_get_temp(struct oscillator *oscillator, double *temp)
```

`mRo50_oscillator.c` function definitions is:

```
static int mRO50_oscillator_get_temp(struct oscillator *oscillator, double *temp)
```

Should it be consistent for the `dummy` and `sim` one?