### PR TITLE
less agressive clock query

### DIFF
--- a/src/oscillatord.c
+++ b/src/oscillatord.c
@@ -353,8 +353,9 @@ int main(int argc, char *argv[])
 				if (ret < 0)
 					error(EXIT_FAILURE, -ret, "oscillator_apply_output");
 			}
-			sleep(SETTLING_TIME);
 		}
+		
+		sleep(SETTLING_TIME);
 
 		if (monitoring_mode) {
 			/* Check for monitoring requests */


### PR DESCRIPTION
When the disciplining is disabled and only the monitoring is enabled, the queries to the clock are very aggressive in a for loop without a sleep.

Should those queries be less aggressive in such cases?