### PR TITLE
[example_configurations] add sa3x

### DIFF
--- a/example_configurations/example_sa3x.conf
+++ b/example_configurations/example_sa3x.conf
@@ -1,0 +1,23 @@
+### Disciplining: ###
+# Wether oscillatord should discipline the oscillator or not
+disciplining=false
+### Monitoring ###
+# Wether oscillatord should expose a socket to send monitoring data
+monitoring=true
+# Monitoring address and port
+socket-address=0.0.0.0
+socket-port=2958
+
+# oscillator name, for now, rakon is the only real simulator supported, two
+# other oscillators exist but are intended for debugging oscillatord: sim and
+# dummy
+oscillator=sa3x
+
+### DEVICES PATHS ###
+# PTP Hardware Clock
+ptp-clock=/dev/ptp2
+# sa3x serial
+sa3x-device=/dev/ttyS6
+# GNSS device
+gnss-device-tty=/dev/ttyS4
+gnss-receiver-reconfigure=true


### PR DESCRIPTION
Follow up from https://github.com/Orolia2s/oscillatord/pull/4

Add example configuration for Microsemi SA3X oscillator.