### PR TITLE
sa5x: v3.0.x update phase error monitoring

### DIFF
--- a/src/oscillatord.c
+++ b/src/oscillatord.c
@@ -506,7 +506,7 @@ int main(int argc, char *argv[])
 				/* this actually means that oscillator has it's own hardware disciplining
 				 * algorithm and we are able to monitor it
 				 */
-				monitoring->phase_error = sign * oscillator_get_phase_error(oscillator, &phase_error);
+				oscillator_get_phase_error(oscillator, &monitoring->phase_error);
 				oscillator_get_disciplining_status(oscillator, &monitoring->disciplining);
 			}
 			monitoring->temperature = temperature;


### PR DESCRIPTION
The monitoring of phase offset was changed when jumping to v3.0.x but was not correctly upgraded during previous PR.
This one fixes the problem and phase offset is now correctly returned in monitoring socket