### PR TITLE
oscillatord: add sleep into main loop

### DIFF
--- a/src/oscillatord.c
+++ b/src/oscillatord.c
@@ -468,8 +468,11 @@ int main(int argc, char *argv[])
 		} else {
 			/* Used for monitoring only */
 			/* Oscillator control values and temperature are needed for
-			* the disciplining algorithm and monitoring, get both of them
-			*/
+			 * the disciplining algorithm and monitoring, get both of them.
+			 * We don't really want to poll atomic clock instantly, so let's
+			 * sleep for a second.
+			 */
+			sleep(1000);
 			ret = oscillator_get_temp(oscillator, &temperature);
 			if (ret == -ENOSYS)
 				temperature = 0;


### PR DESCRIPTION
After '33fca3e Add condvar to phasemeter' the only waiting part is
phasemeter which is not used in monitoring-only mode. This causes
huge resource usage because it polls SA5x/SA3x for monitoring
parameters constantly. Add sleep(1sec) to prevent such behavior