### PR TITLE
SA5x: Provide GNSS information to better control disciplining status

### DIFF
--- a/src/gnss.h
+++ b/src/gnss.h
@@ -179,5 +179,6 @@ int gnss_get_epoch_data(struct gnss *gnss, bool *valid, int32_t *qErr);
 void gnss_stop(struct gnss *gnss);
 void gnss_set_action(struct gnss *gnss, enum gnss_action action);
 int gnss_set_ptp_clock_time(struct gnss *gnss);
+int gnss_get_fix_info(struct gnss *gnss, bool *valid, struct timespec *fixUtc);
 
 #endif

--- a/src/oscillator.c
+++ b/src/oscillator.c
@@ -116,3 +116,12 @@ int oscillator_get_disciplining_status(struct oscillator *oscillator, void *data
 		return -ENOSYS;
 	return oscillator->class->get_disciplining_status(oscillator, data);
 }
+
+int oscillator_push_gnss_info(struct oscillator *oscillator, bool fixOk, const struct timespec *last_fix_utc_time)
+{
+	if (oscillator == NULL)
+		return -EINVAL;
+	if (oscillator->class->push_gnss_info == NULL)
+		return -ENOSYS;
+	return oscillator->class->push_gnss_info(oscillator, fixOk, last_fix_utc_time);
+}

--- a/src/oscillator.h
+++ b/src/oscillator.h
@@ -42,6 +42,7 @@ typedef int (*oscillator_update_disciplining_parameters_cb)(struct oscillator *o
 typedef int (*oscillator_get_phase_error_cb)(struct oscillator *oscillator,
 		int64_t *phase_error);
 typedef int (*oscillator_get_disciplining_status_cb)(struct oscillator *oscillator, void *data);
+typedef int (*oscillator_push_gnss_info_cb)(struct oscillator *oscillator, bool fixOk, const struct timespec *last_fix_utc_time);
 
 struct oscillator_class {
 	const char *name;
@@ -54,6 +55,7 @@ struct oscillator_class {
 	oscillator_update_disciplining_parameters_cb update_disciplining_parameters;
 	oscillator_get_phase_error_cb get_phase_error;
 	oscillator_get_disciplining_status_cb get_disciplining_status;
+	oscillator_push_gnss_info_cb push_gnss_info;
 	/* default values use if per-instance ones haven't been set */
 	uint32_t dac_max;
 	uint32_t dac_min;
@@ -87,6 +89,7 @@ int oscillator_apply_output(struct oscillator *oscillator, struct od_output *out
 int oscillator_get_disciplining_parameters(struct oscillator *oscillator, struct disciplining_parameters * disciplining_parameters);
 int oscillator_update_disciplining_parameters(struct oscillator *oscillator, struct disciplining_parameters *disciplining_parameters);
 int oscillator_get_disciplining_status(struct oscillator *oscillator, void *data);
+int oscillator_push_gnss_info(struct oscillator *oscillator, bool fixOk, const struct timespec *last_fix_utc_time);
 struct calibration_results * oscillator_calibrate(
 	struct oscillator *oscillator,
 	struct phasemeter *phasemeter,

--- a/src/oscillatord.c
+++ b/src/oscillatord.c
@@ -478,7 +478,12 @@ int main(int argc, char *argv[])
 				temperature = 0;
 			else if (ret < 0)
 				error(EXIT_FAILURE, -ret, "oscillator_get_temp");
-
+			if (phase_error_supported) {
+				bool fixOk;
+				struct timespec lastFix;
+				gnss_get_fix_info(gnss, &fixOk, &lastFix);
+				oscillator_push_gnss_info(oscillator, fixOk, &lastFix);
+			}
 			ret = oscillator_get_ctrl(oscillator, &ctrl_values);
 			if (ret != 0) {
 				log_warn("Could not get control values of oscillator");

--- a/src/oscillators/sa5x_oscillator.c
+++ b/src/oscillators/sa5x_oscillator.c
@@ -276,6 +276,7 @@ static int sa5x_oscillator_get_attributes(struct oscillator *oscillator, struct 
 			a->ppsindetected = val;
 		} else {
 			// this is the only parameter that we depend on
+			log_debug("SA5x doesn't return status of PPS signal");
 			return err;
 		}
 		err = sa5x_oscillator_read_intval(&val, sa5x_oscillator_cmd(sa5x, CMD_GET_LOCKED, sizeof(CMD_GET_LOCKED)));
@@ -395,6 +396,9 @@ static int sa5x_oscillator_get_ctrl(struct oscillator *oscillator, struct oscill
 
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 	sa5x = container_of(oscillator, struct sa5x_oscillator, oscillator);
+	if (ctrl->lock == 0 && sa5x->gnss_fix_status) {
+		log_debug("SA5x reports loss of PPS while GNSS fix is OK");
+	}
 	if (!sa5x->gnss_fix_status) {
 		// we are out of GNSS sync, have to restart disciplining
 		// or change state to UNCALIBRATED if we are in HOLDOVER more than 24h


### PR DESCRIPTION
Some more information about GNSS status should be provided to SA5x monitoring module to better describe current Clock Class and Clock Accuracy