### PR TITLE
SA53 improve latching behaviour 

### DIFF
--- a/src/monitoring.c
+++ b/src/monitoring.c
@@ -378,7 +378,7 @@ static void json_add_disciplining_disciplining_parameters(struct json_object *re
 		}
 	}
 	json_object_object_add(disc_parameters_json, "temperature_table", temp_table);
-	json_object_object_add(resp, "disciplining_parameters", disc_parameters_json);	
+	json_object_object_add(resp, "disciplining_parameters", disc_parameters_json);
 	return;
 }
 
@@ -613,7 +613,7 @@ static fd_status_t on_peer_ready_send(int sockfd, struct monitoring * monitoring
  * @param config
  * @return struct monitoring*
  */
-struct monitoring* monitoring_init(const struct config *config, struct devices_path *devices_path)
+struct monitoring* monitoring_init(const struct config *config, struct devices_path *devices_path, const char *oscillator_model)
 {
 	int port;
 	int ret;
@@ -657,6 +657,7 @@ struct monitoring* monitoring_init(const struct config *config, struct devices_p
 	monitoring->disciplining.valid_phase_convergence_threshold = -1;
 	monitoring->disciplining.convergence_progress = 0.00;
 	monitoring->disciplining.ready_for_holdover = false;
+	monitoring->oscillator_model = oscillator_model;
 	monitoring->ctrl_values.fine_ctrl = -1;
 	monitoring->ctrl_values.coarse_ctrl = -1;
 	monitoring->osc_attributes.locked = false;

--- a/src/monitoring.h
+++ b/src/monitoring.h
@@ -55,6 +55,6 @@ struct monitoring {
 	bool phase_error_supported;
 };
 
-struct monitoring* monitoring_init(const struct config *config, struct devices_path *devices_path);
+struct monitoring* monitoring_init(const struct config *config, struct devices_path *devices_path, const char *oscillator_model);
 void monitoring_stop(struct monitoring *monitoring);
 #endif // MONITORING_H


### PR DESCRIPTION
We have seen problems with SA53 going out of range of precise tuning and needs latch command to be issued. But the alarm regarding the issue is not stable. This PR adds logic to issue latch command even if there is no alarm.
Another commit fixing race condition and possible null-pointer resolution while initialising monitoring thread.