### PR TITLE
Build with -D_GNU_SOURCE for a declaration of clock_adjtime in <time.h>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_definitions("
     -Wmissing-prototypes
     -Wpointer-arith
     -DLOG_USE_COLOR")
+add_definitions("-D_GNU_SOURCE")
 add_definitions("-DOD_REVISION=\"${PACKAGE_VERSION}\"")
 
 add_subdirectory(src)


### PR DESCRIPTION
This function is called in some source files.  Before this change, this compiled only on compilers which support implicit function declarations, a feature that was removed from the C language in 1999.

Related to:

  <https://fedoraproject.org/wiki/Changes/PortingToModernC>
  <https://fedoraproject.org/wiki/Toolchain/PortingToModernC>
