### PR TITLE
Do not access unused memory

### DIFF
--- a/common/gnss-config.c
+++ b/common/gnss-config.c
@@ -503,7 +503,7 @@ static bool _cfgDbAddKeyVal(CFG_DB_t *db, IO_LINE_t *line, const uint32_t id, co
         return false;
     }
 
-    for (int ix = 0; ix < db->maxKv; ix++)
+    for (int ix = 0; ix < db->nKv; ix++)
     {
         if (db->kv[ix].id == id)
         {

--- a/src/monitoring.c
+++ b/src/monitoring.c
@@ -748,7 +748,7 @@ void monitoring_stop(struct monitoring *monitoring)
 	pthread_cond_signal(&monitoring->cond);
 	pthread_mutex_unlock(&monitoring->mutex);
 	pthread_join(monitoring->thread, NULL);
-
+	close(monitoring->sockfd);
 	free(monitoring);
 	return;
 }


### PR DESCRIPTION
 * Only check used kev-value pairs for duplicates
 * Close the socket's file-descriptor when stoping the monitoring