### PR TITLE
[sa53] set first TAU to 10

### DIFF
--- a/src/oscillators/sa5x_oscillator.c
+++ b/src/oscillators/sa5x_oscillator.c
@@ -47,7 +47,7 @@
 
 #define DISCIPLINING_PHASES 3
 
-static const unsigned int tau_values[DISCIPLINING_PHASES] = {50, 500, 10000};
+static const unsigned int tau_values[DISCIPLINING_PHASES] = {10, 500, 10000};
 static const unsigned int tau_interval[DISCIPLINING_PHASES] = {600, 7200, 86400}; // in seconds
 
 enum SA5x_ClockClass {


### PR DESCRIPTION
We found out that right after restart `gnss` is being unstable and having a relatively large TAU (50) significantly impacts the time to lock/stabilize the phase. Setting TAU to 10 leads to a faster convergence of phase which leads to a faster sa53 lock state (less than 20 minutes)

![image](https://github.com/Orolia2s/oscillatord/assets/4749052/61400165-9372-4fbd-ba9a-894ba3e3aa6f)

