### PR TITLE
sa5x: don't go to HOLDOVER when GNSS port times out

### DIFF
--- a/src/oscillatord.c
+++ b/src/oscillatord.c
@@ -598,8 +598,8 @@ int main(int argc, char *argv[])
 			} else if (ret < 0)
 				error(EXIT_FAILURE, -ret, "oscillator_get_temp");
 			if (phase_error_supported) {
-				bool fixOk;
-				struct timespec lastFix;
+				bool fixOk = false;
+				struct timespec lastFix = {};
 				gnss_get_fix_info(gnss, &fixOk, &lastFix);
 				oscillator_push_gnss_info(oscillator, fixOk, &lastFix);
 			}


### PR DESCRIPTION
We have some issues with reading from GNSS port which ends up having one second of no GNSS fix and move SA53 to holdover. It looks like the issue is related to serial port rather then GNSS because SA53 can see the PPS-in signal. Skip transition to HOLDOVER status in such case.

Also fix some uninitialized usage of variables around GNSS.