### PR TITLE
sa53: adjust GNSS UART timeout value

### DIFF
--- a/src/oscillators/sa5x_oscillator.c
+++ b/src/oscillators/sa5x_oscillator.c
@@ -19,7 +19,7 @@
 #define MAX_SERIALNUM_LENGTH 11
 #define DIGITAL_TUNING_MAX 20000000LL
 #define DEFAULT_PHASELIMIT 100000 // Phase limit is 100us
-#define NO_GNSS_FIX_TIMEOUT 3 // seconds after last gnss Fix befor holdover
+#define NO_GNSS_FIX_TIMEOUT 9 // seconds after last gnss Fix befor holdover
 #define BIT(nr)			(1UL << (nr))
 
 #define ATTR_FW_SERIAL    		BIT(0)


### PR DESCRIPTION
Every time the UART timeout happens it takes minimum 3 seconds to recover the communication. That's why previously configured value did help to avoid going to HOLDOVER. Adjust the value to go to holdover after 3 consecutve timeouts.