### PR TITLE
Monitoring rework

### DIFF
--- a/src/gnss.c
+++ b/src/gnss.c
@@ -943,6 +943,22 @@ static void * gnss_thread(void * p_data)
 			pthread_mutex_unlock(&gnss->mutex_data);
 			usleep(5 * 1000);
 		}
+
+		/* this thread is the only writer to gnss->session, it's safe read the same values without mutex_data locked */
+		if (gnss->gnss_info) {
+			struct gnss_state *gnss_info = gnss->gnss_info;
+			pthread_mutex_lock(&gnss_info->lock);
+			gnss_info->antenna_power = gnss->session->antenna_power;
+			gnss_info->antenna_status = gnss->session->antenna_status;
+			gnss_info->fix = gnss->session->fix;
+			gnss_info->fixOk = gnss->session->fixOk;
+			gnss_info->leap_seconds = gnss->session->context->leap_seconds;
+			gnss_info->lsChange = gnss->session->context->lsChange;
+			gnss_info->satellites_count = gnss->session->satellites_count;
+			gnss_info->survey_in_position_error = gnss->session->survey_in_position_error;
+			pthread_mutex_unlock(&gnss_info->lock);
+		}
+
 		pthread_mutex_lock(&gnss->mutex_data);
 		stop = gnss->stop;
 		action = gnss->action;

--- a/src/gnss.h
+++ b/src/gnss.h
@@ -125,6 +125,23 @@ struct gps_context_t {
 		const char *buf, const size_t len);
 };
 
+
+/**
+ * @struct gnss_state
+ * @brief Structure containing data with the latest gnss values
+ */
+struct gnss_state {
+	float survey_in_position_error;
+	int fix;
+	int satellites_count;
+	int leap_seconds;
+	int lsChange;
+	int8_t antenna_power;
+	int8_t antenna_status;
+	bool fixOk;
+	pthread_mutex_t lock;
+};
+
 /**
  * @struct gps_device_t
  * @brief Structure containing data about the gnss device
@@ -180,6 +197,7 @@ struct gnss {
 	bool stop;
 	int receiver_version_major;
 	int receiver_version_minor;
+	struct gnss_state *gnss_info;
 };
 
 struct gnss* gnss_init(const struct config *config, char *gnss_device_tty, struct gps_device_t *session, int fd_clock);

--- a/src/monitoring.c
+++ b/src/monitoring.c
@@ -498,7 +498,7 @@ static void json_add_clock_data(struct json_object *resp, struct monitoring *mon
 		json_object_new_string(cstring_from_clock_class(monitoring->disciplining.clock_class))
 	);
 	json_object_object_add(clock, "offset",
-		json_object_new_int(monitoring->phase_error));
+		json_object_new_int(monitoring->osc_attributes.phase_error));
 
 	json_object_object_add(resp, "clock", clock);
 
@@ -574,21 +574,21 @@ static void json_add_gnss_data(struct json_object *resp, struct monitoring *moni
 {
 	struct json_object *gnss = json_object_new_object();
 	json_object_object_add(gnss, "fix",
-		json_object_new_int(monitoring->fix));
+		json_object_new_int(monitoring->gnss_info.fix));
 	json_object_object_add(gnss, "fixOk",
-		json_object_new_boolean(monitoring->fixOk));
+		json_object_new_boolean(monitoring->gnss_info.fixOk));
 	json_object_object_add(gnss, "antenna_power",
-		json_object_new_int(monitoring->antenna_power));
+		json_object_new_int(monitoring->gnss_info.antenna_power));
 	json_object_object_add(gnss, "antenna_status",
-		json_object_new_int(monitoring->antenna_status));
+		json_object_new_int(monitoring->gnss_info.antenna_status));
 	json_object_object_add(gnss, "lsChange",
-		json_object_new_int(monitoring->lsChange));
+		json_object_new_int(monitoring->gnss_info.lsChange));
 	json_object_object_add(gnss, "leap_seconds",
-		json_object_new_int(monitoring->leap_seconds));
+		json_object_new_int(monitoring->gnss_info.leap_seconds));
 	json_object_object_add(gnss, "satellites_count",
-		json_object_new_int(monitoring->satellites_count));
+		json_object_new_int(monitoring->gnss_info.satellites_count));
 	json_object_object_add(gnss, "survey_in_position_error",
-		json_object_new_int(monitoring->survey_in_position_error));
+		json_object_new_int(monitoring->gnss_info.survey_in_position_error));
 
 	json_object_object_add(resp, "gnss", gnss);
 }
@@ -718,16 +718,16 @@ struct monitoring* monitoring_init(const struct config *config, struct devices_p
 	monitoring->ctrl_values.coarse_ctrl = -1;
 	monitoring->osc_attributes.locked = false;
 	monitoring->osc_attributes.temperature = -400.0;
+	monitoring->osc_attributes.phase_error = 0;
 
-	monitoring->antenna_power = -1;
-	monitoring->antenna_status = -1;
-	monitoring->leap_seconds = -1;
-	monitoring->phase_error = 0;
-	monitoring->fix = -1;
-	monitoring->fixOk = false;
-	monitoring->lsChange = -10;
-	monitoring->satellites_count = -1;
-	monitoring->survey_in_position_error = -1.0;
+	monitoring->gnss_info.antenna_power = -1;
+	monitoring->gnss_info.antenna_status = -1;
+	monitoring->gnss_info.leap_seconds = -1;
+	monitoring->gnss_info.fix = -1;
+	monitoring->gnss_info.fixOk = false;
+	monitoring->gnss_info.lsChange = -10;
+	monitoring->gnss_info.satellites_count = -1;
+	monitoring->gnss_info.survey_in_position_error = -1.0;
 	pthread_mutex_init(&monitoring->mutex, NULL);
 	pthread_cond_init(&monitoring->cond, NULL);
 

--- a/src/monitoring.h
+++ b/src/monitoring.h
@@ -33,17 +33,6 @@ enum monitoring_request {
 	REQUEST_RESET_UBLOX_SERIAL
 };
 
-struct gnss_state {
-	float survey_in_position_error;
-	int fix;
-	int satellites_count;
-	int leap_seconds;
-	int lsChange;
-	int8_t antenna_power;
-	int8_t antenna_status;
-	bool fixOk;
-};
-
 /**
  * @brief General structure for monitoring thread
  */

--- a/src/monitoring.h
+++ b/src/monitoring.h
@@ -33,6 +33,17 @@ enum monitoring_request {
 	REQUEST_RESET_UBLOX_SERIAL
 };
 
+struct gnss_state {
+	float survey_in_position_error;
+	int fix;
+	int satellites_count;
+	int leap_seconds;
+	int lsChange;
+	int8_t antenna_power;
+	int8_t antenna_status;
+	bool fixOk;
+};
+
 /**
  * @brief General structure for monitoring thread
  */
@@ -44,18 +55,10 @@ struct monitoring {
 	struct od_monitoring disciplining;
 	struct oscillator_ctrl ctrl_values;
 	struct oscillator_attributes osc_attributes;
+	struct gnss_state gnss_info;
 	const char *oscillator_model;
 	struct devices_path devices_path;
-	int64_t phase_error;
-	int fix;
-	int satellites_count;
-	float survey_in_position_error;
-	int leap_seconds;
-	int lsChange;
-	int8_t antenna_power;
-	int8_t antenna_status;
 	int sockfd;
-	bool fixOk;
 	bool stop;
 	bool disciplining_mode;
 	bool phase_error_supported;

--- a/src/oscillator.h
+++ b/src/oscillator.h
@@ -75,6 +75,7 @@ struct oscillator_ctrl {
 };
 
 struct oscillator_attributes {
+	int64_t phase_error;
 	double temperature;
 	bool locked;
 };


### PR DESCRIPTION
Reduce the scope of monitoring mutex lock and move GNSS monitoring under another mutex with GNSS thread filling the data.