### PR TITLE
Timecard driver update

### DIFF
--- a/common/config.h
+++ b/common/config.h
@@ -52,4 +52,7 @@ void config_cleanup(struct config *config);
 
 void config_dump(const struct config *config, char *buf, size_t buf_len);
 int config_save(struct config *config, const char *path);
+
+/* discovers devices from sysfs path */
+int config_discover_devices(const struct config *config, struct devices_path *devices_path);
 #endif /* CONFIG_H_ */

--- a/src/monitoring.c
+++ b/src/monitoring.c
@@ -733,6 +733,7 @@ struct monitoring* monitoring_init(const struct config *config, struct devices_p
 	monitoring->gnss_info.lsChange = -10;
 	monitoring->gnss_info.satellites_count = -1;
 	monitoring->gnss_info.survey_in_position_error = -1.0;
+	monitoring->gnss_info.time_accuracy = -1;
 	pthread_mutex_init(&monitoring->gnss_info.lock, NULL);
 
 	pthread_mutex_init(&monitoring->mutex, NULL);

--- a/src/oscillatord.c
+++ b/src/oscillatord.c
@@ -162,53 +162,6 @@ static void prepare_minipod_config(struct minipod_config* minipod_config, struct
 	minipod_config->fine_table_output_path = config_get_default(config, "fine_table_output_path", "/tmp/");
 }
 
-static int get_devices_path_from_sysfs(
-	struct config *config,
-	struct devices_path *devices_path
-) {
-	const char *sysfs_path;
-	DIR * ocp_dir;
-
-	sysfs_path = config_get(config, "sysfs-path");
-	if (sysfs_path == NULL) {
-		log_error("No sysfs-path provided in oscillatord config file !");
-		return -EINVAL;
-	}
-	log_info("Scanning sysfs path %s", sysfs_path);
-
-	ocp_dir = opendir(sysfs_path);
-	struct dirent * entry = readdir(ocp_dir);
-	while (entry != NULL) {
-		if (strcmp(entry->d_name, "mro50") == 0) {
-			find_dev_path(sysfs_path, entry, devices_path->mro_path);
-			log_debug("mro50 device detected: %s", devices_path->mro_path);
-		} else if (strcmp(entry->d_name, "ptp") == 0) {
-			find_dev_path(sysfs_path, entry, devices_path->ptp_path);
-			log_debug("ptp clock device detected: %s", devices_path->ptp_path);
-		} else if (strcmp(entry->d_name, "pps") == 0) {
-			find_dev_path(sysfs_path, entry, devices_path->pps_path);
-			log_debug("pps device detected: %s", devices_path->pps_path);
-		} else if (strcmp(entry->d_name, "ttyGNSS") == 0) {
-			find_dev_path(sysfs_path, entry, devices_path->gnss_path);
-			log_debug("ttyGPS detected: %s", devices_path->gnss_path);
-		} else if (strcmp(entry->d_name, "ttyMAC") == 0) {
-			find_dev_path(sysfs_path, entry, devices_path->mac_path);
-			log_debug("ttyMAC detected: %s", devices_path->mac_path);
-		} else if (strcmp(entry->d_name, "disciplining_config") == 0) {
-			find_file((char *) sysfs_path, "disciplining_config", devices_path->disciplining_config_path);
-			log_debug("disciplining_config detected: %s", devices_path->disciplining_config_path);
-		} else if (strcmp(entry->d_name, "temperature_table") == 0) {
-			find_file((char *) sysfs_path, "temperature_table", devices_path->temperature_table_path);
-			log_debug("temperature_table detected: %s", devices_path->temperature_table_path);
-		}
-
-		entry = readdir(ocp_dir);
-	}
-
-	return 0;
-}
-
-
 /**
  * @brief Main program function
  *
@@ -270,7 +223,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Get devices' path from sysfs directory */
-	ret = get_devices_path_from_sysfs(&config, &devices_path);
+	ret = config_discover_devices(&config, &devices_path);
 	if (ret != 0) {
 		error(EXIT_FAILURE, -ret, "get_devices_path_from_sysfs");
 		return -EINVAL;

--- a/tests/art_integration_in_server_test.c
+++ b/tests/art_integration_in_server_test.c
@@ -183,7 +183,7 @@ static void prepare_config_file_for_oscillatord(struct devices_path* devices_pat
 }
 
 int main(int argc, char* argv[]) {
-    struct devices_path devices_path;
+    struct devices_path devices_path = {0};
     struct config       config;
     char*               sysfs_path = NULL;
     char                ocp_name[100];


### PR DESCRIPTION
The new kernel version doesn't support symlinks to tty devices anymore. The update will be to export these devices as a group of attributes which contain ttySx string. Adjust oscillatord code to use these new attributes.

Also, the last commit is about to fix initialization of the previously added monitoring parameter.