### PR TITLE
Add ubloxcfg 1.16 compatibility

### DIFF
--- a/.github/workflows/build-oscillatord.yaml
+++ b/.github/workflows/build-oscillatord.yaml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v3
       with:
           repository: orolia2s/ubloxcfg
-          ref: 1.15
+          ref: master
     - name: Compile Ublox configuration shared library
       run: make libubloxcfg.so
     - name: Install it

--- a/.github/workflows/build-oscillatord.yaml
+++ b/.github/workflows/build-oscillatord.yaml
@@ -15,11 +15,13 @@ jobs:
       uses: actions/checkout@v3
       with:
           repository: orolia2s/ubloxcfg
-          ref: 1.15
+          ref: main
     - name: Compile Ublox configuration shared library
-      run: make libubloxcfg.so
+      run: |
+        cmake -S . -B build
+        cmake --build build
     - name: Install it
-      run: sudo make install-library
+      run: sudo cmake --install build
 
     - name: Clone Discipline minipod
       uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 pkg_check_modules(oscillator-disciplining REQUIRED liboscillator-disciplining)
-pkg_check_modules(ubloxcfg REQUIRED libubloxcfg)
+pkg_check_modules(ubloxcfg REQUIRED ubloxcfg ff)
 pkg_check_modules(json-c REQUIRED json-c)
 
 ADD_DEFINITIONS( -DPACKAGE_VERSION=\"${PACKAGE_VERSION}\" )

--- a/common/gnss-config.c
+++ b/common/gnss-config.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <ubloxcfg/ff_ubx.h>
+#include <ff/ff_ubx.h>
 
 #include "gnss-config.h"
 

--- a/common/gnss-config.h
+++ b/common/gnss-config.h
@@ -1,7 +1,7 @@
 #ifndef OSCILLATORD_GNSS_CONFIG_H
 #define OSCILLATORD_GNSS_CONFIG_H
 
-#include <ubloxcfg/ff_rx.h>
+#include <ff/ff_rx.h>
 #include <ubloxcfg/ubloxcfg.h>
 
 bool check_gnss_config_in_ram(RX_t *rx, UBLOXCFG_KEYVAL_t *allKvCfg, int nAllKvCfg);

--- a/src/gnss.c
+++ b/src/gnss.c
@@ -215,7 +215,7 @@ static void gnss_parse_ubx_tim_tp(struct gps_device_t *session, PARSER_MSG_t *ms
 
 		log_trace("UBX-TIM-TP: towMS %u, towSubMs %u, qErr %i, week %hu, flags %#hhx; refInfo %#hhx",
 		          gr0.towMs,
-		          gr0.towSubMS,
+		          gr0.towSubMs,
 		          gr0.qErr,
 		          gr0.week,
 		          gr0.flags,
@@ -223,17 +223,17 @@ static void gnss_parse_ubx_tim_tp(struct gps_device_t *session, PARSER_MSG_t *ms
 
 		int offset = 0;
 		if (UBX_TIM_TP_V0_FLAGS_TIMEBASE_GET(gr0.flags) == UBX_TIM_TP_V0_FLAGS_TIMEBASE_GNSS) {
-			switch(UBX_TIM_TP_V0_REFINFO_GET(gr0.refInfo)) {
-				case UBX_TIM_TP_V0_REFINFO_GPS:
+			switch(UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_GET(gr0.refInfo)) {
+				case UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_GPS:
 					offset = GPS_EPOCH_TO_TAI;
 					break;
-				case UBX_TIM_TP_V0_REFINFO_BDS:
+				case UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_BDS:
 					offset = BDS_EPOCH_TO_TAI;
 					break;
-				case UBX_TIM_TP_V0_REFINFO_GAL:
+				case UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_GAL:
 					offset = GAL_EPOCH_TO_TAI;
 					break;
-				case UBX_TIM_TP_V0_REFINFO_GLO:
+				case UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_GLO:
 					if (session->context->lsset) {
 						offset = GLO_EPOCH_TO_TAI + session->context->leap_seconds;
 					} else {
@@ -242,7 +242,7 @@ static void gnss_parse_ubx_tim_tp(struct gps_device_t *session, PARSER_MSG_t *ms
 					}
 					break;
 				default:
-					log_error("Unhandled Constellations %d", UBX_TIM_TP_V0_REFINFO_GET(gr0.refInfo));
+					log_error("Unhandled Constellations %d", UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_GET(gr0.refInfo));
 					return;
 			}
 		} else if (UBX_TIM_TP_V0_FLAGS_TIMEBASE_GET(gr0.flags) == UBX_TIM_TP_V0_FLAGS_TIMEBASE_UTC) {
@@ -702,12 +702,12 @@ struct gnss * gnss_init(const struct config *config, char *gnss_device_tty, stru
 {
 	struct gnss* gnss;
 	int          ret  = -1;
-	RX_ARGS_t    args = RX_ARGS_DEFAULT();
-	args.autobaud     = true;
-	args.detect       = true;
+	RX_OPTS_t    opts = RX_OPTS_DEFAULT();
+	opts.autobaud     = true;
+	opts.detect       = RX_DET_UBX;
 
 	if (strchr(gnss_device_tty, '@')) {
-		args.autobaud = false;
+		opts.autobaud = false;
 	}
 
 	if (session == NULL) {
@@ -727,7 +727,7 @@ struct gnss * gnss_init(const struct config *config, char *gnss_device_tty, stru
 	/* Init Antenna Status and Power to undefined values according to UBX Protocol */
 	gnss->session->antenna_status = ANT_STATUS_UNDEFINED;
 	gnss->session->antenna_power = ANT_POWER_UNDEFINED;
-	gnss->rx = rxInit(gnss_device_tty, &args);
+	gnss->rx = rxInit(gnss_device_tty, &opts);
 	gnss->action = GNSS_ACTION_NONE;
 	/* Init Survey In Error to undefined values */
 	gnss->session->survey_in_position_error =-1.0;

--- a/src/gnss.c
+++ b/src/gnss.c
@@ -11,11 +11,11 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <ubloxcfg/ff_epoch.h>
-#include <ubloxcfg/ff_parser.h>
-#include <ubloxcfg/ff_rx.h>
-#include <ubloxcfg/ff_stuff.h>
-#include <ubloxcfg/ff_ubx.h>
+#include <ff/ff_epoch.h>
+#include <ff/ff_parser.h>
+#include <ff/ff_rx.h>
+#include <ff/ff_stuff.h>
+#include <ff/ff_ubx.h>
 #include <ubloxcfg/ubloxcfg.h>
 
 #include "gnss.h"
@@ -215,7 +215,7 @@ static void gnss_parse_ubx_tim_tp(struct gps_device_t *session, PARSER_MSG_t *ms
 
 		log_trace("UBX-TIM-TP: towMS %u, towSubMs %u, qErr %i, week %hu, flags %#hhx; refInfo %#hhx",
 		          gr0.towMs,
-		          gr0.towSubMS,
+		          gr0.towSubMs,
 		          gr0.qErr,
 		          gr0.week,
 		          gr0.flags,
@@ -223,17 +223,17 @@ static void gnss_parse_ubx_tim_tp(struct gps_device_t *session, PARSER_MSG_t *ms
 
 		int offset = 0;
 		if (UBX_TIM_TP_V0_FLAGS_TIMEBASE_GET(gr0.flags) == UBX_TIM_TP_V0_FLAGS_TIMEBASE_GNSS) {
-			switch(UBX_TIM_TP_V0_REFINFO_GET(gr0.refInfo)) {
-				case UBX_TIM_TP_V0_REFINFO_GPS:
+			switch(UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_GET(gr0.refInfo)) {
+				case UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_GPS:
 					offset = GPS_EPOCH_TO_TAI;
 					break;
-				case UBX_TIM_TP_V0_REFINFO_BDS:
+				case UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_BDS:
 					offset = BDS_EPOCH_TO_TAI;
 					break;
-				case UBX_TIM_TP_V0_REFINFO_GAL:
+				case UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_GAL:
 					offset = GAL_EPOCH_TO_TAI;
 					break;
-				case UBX_TIM_TP_V0_REFINFO_GLO:
+				case UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_GLO:
 					if (session->context->lsset) {
 						offset = GLO_EPOCH_TO_TAI + session->context->leap_seconds;
 					} else {
@@ -242,7 +242,7 @@ static void gnss_parse_ubx_tim_tp(struct gps_device_t *session, PARSER_MSG_t *ms
 					}
 					break;
 				default:
-					log_error("Unhandled Constellations %d", UBX_TIM_TP_V0_REFINFO_GET(gr0.refInfo));
+					log_error("Unhandled Constellations %d", UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_GET(gr0.refInfo));
 					return;
 			}
 		} else if (UBX_TIM_TP_V0_FLAGS_TIMEBASE_GET(gr0.flags) == UBX_TIM_TP_V0_FLAGS_TIMEBASE_UTC) {
@@ -702,12 +702,12 @@ struct gnss * gnss_init(const struct config *config, char *gnss_device_tty, stru
 {
 	struct gnss* gnss;
 	int          ret  = -1;
-	RX_ARGS_t    args = RX_ARGS_DEFAULT();
-	args.autobaud     = true;
-	args.detect       = true;
+	RX_OPTS_t    opts = RX_OPTS_DEFAULT();
+	opts.autobaud     = true;
+	opts.detect       = RX_DET_UBX;
 
 	if (strchr(gnss_device_tty, '@')) {
-		args.autobaud = false;
+		opts.autobaud = false;
 	}
 
 	if (session == NULL) {
@@ -727,7 +727,7 @@ struct gnss * gnss_init(const struct config *config, char *gnss_device_tty, stru
 	/* Init Antenna Status and Power to undefined values according to UBX Protocol */
 	gnss->session->antenna_status = ANT_STATUS_UNDEFINED;
 	gnss->session->antenna_power = ANT_POWER_UNDEFINED;
-	gnss->rx = rxInit(gnss_device_tty, &args);
+	gnss->rx = rxInit(gnss_device_tty, &opts);
 	gnss->action = GNSS_ACTION_NONE;
 	/* Init Survey In Error to undefined values */
 	gnss->session->survey_in_position_error =-1.0;

--- a/src/gnss.h
+++ b/src/gnss.h
@@ -15,7 +15,7 @@
 #ifndef OSCILLATORD_GNSS_H
 #define OSCILLATORD_GNSS_H
 
-#include <ubloxcfg/ff_rx.h>
+#include <ff/ff_rx.h>
 #include <pthread.h>
 #include <termios.h>
 

--- a/tests/art_integration_testsuite/gnss_serial_test.c
+++ b/tests/art_integration_testsuite/gnss_serial_test.c
@@ -31,11 +31,11 @@ bool test_gnss_serial(char* path) {
         log_error("\t- GNSS Path does not exists");
         return false;
     }
-    RX_ARGS_t args = RX_ARGS_DEFAULT();
-    args.autobaud  = true;
-    args.detect    = true;
+    RX_OPTS_t opts = RX_OPTS_DEFAULT();
+    opts.autobaud  = true;
+    opts.detect    = RX_DET_UBX;
     log_info("Path is %s", path);
-    RX_t* rx = rxInit(path, &args);
+    RX_t* rx = rxInit(path, &opts);
 
     if (!rxOpen(rx)) {
         free(rx);

--- a/tests/art_integration_testsuite/gnss_serial_test.c
+++ b/tests/art_integration_testsuite/gnss_serial_test.c
@@ -1,9 +1,9 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <ubloxcfg/ff_epoch.h>
-#include <ubloxcfg/ff_rx.h>
-#include <ubloxcfg/ff_ubx.h>
+#include <ff/ff_epoch.h>
+#include <ff/ff_rx.h>
+#include <ff/ff_ubx.h>
 
 #include "gnss_serial_test.h"
 
@@ -31,11 +31,11 @@ bool test_gnss_serial(char* path) {
         log_error("\t- GNSS Path does not exists");
         return false;
     }
-    RX_ARGS_t args = RX_ARGS_DEFAULT();
-    args.autobaud  = true;
-    args.detect    = true;
+    RX_OPTS_t opts = RX_OPTS_DEFAULT();
+    opts.autobaud  = true;
+    opts.detect    = RX_DET_UBX;
     log_info("Path is %s", path);
-    RX_t* rx = rxInit(path, &args);
+    RX_t* rx = rxInit(path, &opts);
 
     if (!rxOpen(rx)) {
         free(rx);

--- a/tests_production/gnss_config_prod.c
+++ b/tests_production/gnss_config_prod.c
@@ -62,11 +62,11 @@ int main(int argc, char *argv[])
 
     if (gnss_path_valid)
     {
-        RX_ARGS_t args = RX_ARGS_DEFAULT();
-        args.autobaud = true;
-        args.detect = true;
+        RX_OPTS_t opts = RX_OPTS_DEFAULT();
+        opts.autobaud = true;
+        opts.detect = RX_DET_UBX;
         log_info("Path is %s", gnss_path);
-        RX_t * rx = rxInit(gnss_path, &args);
+        RX_t * rx = rxInit(gnss_path, &opts);
 
         if (!rxOpen(rx)) {
             free(rx);

--- a/tests_production/gnss_config_prod.c
+++ b/tests_production/gnss_config_prod.c
@@ -1,8 +1,8 @@
 #include <stdlib.h>
 #include <unistd.h>
-#include <ubloxcfg/ff_epoch.h>
-#include <ubloxcfg/ff_rx.h>
-#include <ubloxcfg/ff_ubx.h>
+#include <ff/ff_epoch.h>
+#include <ff/ff_rx.h>
+#include <ff/ff_ubx.h>
 #include <dirent.h>
 #include <string.h>
 #include <stdio.h>
@@ -62,11 +62,11 @@ int main(int argc, char *argv[])
 
     if (gnss_path_valid)
     {
-        RX_ARGS_t args = RX_ARGS_DEFAULT();
-        args.autobaud = true;
-        args.detect = true;
+        RX_OPTS_t opts = RX_OPTS_DEFAULT();
+        opts.autobaud = true;
+        opts.detect = RX_DET_UBX;
         log_info("Path is %s", gnss_path);
-        RX_t * rx = rxInit(gnss_path, &args);
+        RX_t * rx = rxInit(gnss_path, &opts);
 
         if (!rxOpen(rx)) {
             free(rx);

--- a/tests_production/gnss_test_prod.c
+++ b/tests_production/gnss_test_prod.c
@@ -69,11 +69,11 @@ int main(int argc, char *argv[])
 
     if (gnss_path_valid)
     {
-        RX_ARGS_t args = RX_ARGS_DEFAULT();
-        args.autobaud = true;
-        args.detect = true;
+        RX_OPTS_t opts = RX_OPTS_DEFAULT();
+        opts.autobaud = true;
+        opts.detect = RX_DET_UBX;
         log_info("Path is %s", gnss_path);
-        RX_t * rx = rxInit(gnss_path, &args);
+        RX_t * rx = rxInit(gnss_path, &opts);
 
         if (!rxOpen(rx)) {
             free(rx);

--- a/tests_production/gnss_test_prod.c
+++ b/tests_production/gnss_test_prod.c
@@ -1,9 +1,9 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdbool.h>
-#include <ubloxcfg/ff_epoch.h>
-#include <ubloxcfg/ff_rx.h>
-#include <ubloxcfg/ff_ubx.h>
+#include <ff/ff_epoch.h>
+#include <ff/ff_rx.h>
+#include <ff/ff_ubx.h>
 #include <dirent.h>
 #include <string.h>
 #include <stdio.h>
@@ -69,11 +69,11 @@ int main(int argc, char *argv[])
 
     if (gnss_path_valid)
     {
-        RX_ARGS_t args = RX_ARGS_DEFAULT();
-        args.autobaud = true;
-        args.detect = true;
+        RX_OPTS_t opts = RX_OPTS_DEFAULT();
+        opts.autobaud = true;
+        opts.detect = RX_DET_UBX;
         log_info("Path is %s", gnss_path);
-        RX_t * rx = rxInit(gnss_path, &args);
+        RX_t * rx = rxInit(gnss_path, &opts);
 
         if (!rxOpen(rx)) {
             free(rx);


### PR DESCRIPTION
Description:
ubloxcfg 1.16 (commit 2779fd3) introduced several breaking API changes that prevent oscillatord from building against it. This patch updates oscillatord to use the new API names.

Changes:
- RX_ARGS_t → RX_OPTS_t, RX_ARGS_DEFAULT() → RX_OPTS_DEFAULT()
- towSubMS → towSubMs
- UBX_TIM_TP_V0_REFINFO_* → UBX_TIM_TP_V0_REFINFO_TIMEREFGNSS_*
- pkg-config module: libubloxcfg → ubloxcfg (also add ff dependency, since 1.16 ships them as separate libraries)
- Include paths: <ubloxcfg/ff_*.h> → <ff/ff_*.h> (1.16 installs ff headers separately)

Tested against ubloxcfg-devel-1.16-2.20260223git499048b on Fedora 43:

```
$ wget https://github.com/ESoapW/oscillatord/archive/ubloxcfg-1.16-compat.tar.gz
$ tar xzf ubloxcfg-1.16-compat.tar.gz
$ cd oscillatord-ubloxcfg-1.16-compat

$ rpm -q ubloxcfg-devel
ubloxcfg-devel-1.16-2.20260223git499048b.fc43.x86_64

$ mkdir build && cd build
$ cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_UTILS=1 ..
-- Found PkgConfig: /usr/bin/pkg-config (found version "2.3.0")
oscillatord version is 3.9.0
-- The C compiler identification is GNU 15.2.1
-- Checking for module 'liboscillator-disciplining'
--   Found liboscillator-disciplining, version
-- Checking for modules 'ubloxcfg;ff'
--   Found ubloxcfg, version 0.0.0
--   Found ff, version 0.0.0
-- Checking for module 'json-c'
--   Found json-c, version 0.18
-- Configuring done (1.4s)
-- Generating done (0.0s)

$ make
[  1%] Building C object src/CMakeFiles/oscillatord.dir/gnss.c.o
...
[ 37%] Linking C executable oscillatord
[ 37%] Built target oscillatord
...
[ 47%] Built target art_disciplining_manager
...
[ 59%] Built target art_eeprom_format
...
[ 70%] Built target art_eeprom_reformat
...
[ 80%] Built target art_monitoring_client
...
[ 90%] Built target art_temperature_table_manager
...
[100%] Built target art_eeprom_files_updater

$ cat systemd/oscillatord.service
[Unit]
Description=Daemon responsible of disciplining an oscillator based on a 1pps phase error device.

[Service]
Type=simple
ExecStart=/usr/bin/oscillatord /etc/oscillatord.conf

[Install]
WantedBy=multi-user.target
```