### PR TITLE
mro50: configure serial port explicitly

### DIFF
--- a/src/oscillators/mRo50_oscillator.c
+++ b/src/oscillators/mRo50_oscillator.c
@@ -110,6 +110,8 @@ static int set_serial_attributes(int fd)
 	tty.c_oflag = 0;			// no remapping, no delays
 
 	tty.c_iflag &= ~(IXON | IXOFF | IXANY); // shut off xon/xoff ctrl
+	tty.c_iflag &= ~(INLCR | IGNCR); // no CR/LF translation on input
+	tty.c_iflag |= ICRNL;
 
 	tty.c_cflag |= (CLOCAL | CREAD);	// ignore modem controls,
 						// enable reading


### PR DESCRIPTION
mRO50 communication protocol expects CR to be translated to LF. Set the translation explicitly while configuring serial port.