### PR TITLE
[oscillatord] fix set_rtcm_output to avoid receiver restart

### DIFF
--- a/src/gnss.c
+++ b/src/gnss.c
@@ -489,6 +489,50 @@ static bool set_cable_delay(UBLOXCFG_KEYVAL_t* keyValuePairs, size_t length, con
 }
 
 /**
+ * @brief Patch RTCM message rates and UART1 output protocol in the config array.
+ *
+ * When gnss-rtcm-enabled=true, sets RTCM UART1 message rates to 1 and enables
+ * the RTCM3 output protocol on UART1 in the reference config array so the
+ * comparison against the receiver's current config will match.
+ */
+static bool set_rtcm_output(UBLOXCFG_KEYVAL_t* keyValuePairs, size_t length, const struct config* config)
+{
+	if (!config_get_bool_default(config, "gnss-rtcm-enabled", false))
+		return false;
+
+	static const uint32_t rtcm_uart1_ids[] = {
+		UBLOXCFG_CFG_MSGOUT_RTCM_3X_TYPE1005_UART1_ID,
+		UBLOXCFG_CFG_MSGOUT_RTCM_3X_TYPE1077_UART1_ID,
+		UBLOXCFG_CFG_MSGOUT_RTCM_3X_TYPE1087_UART1_ID,
+		UBLOXCFG_CFG_MSGOUT_RTCM_3X_TYPE1097_UART1_ID,
+		UBLOXCFG_CFG_MSGOUT_RTCM_3X_TYPE1127_UART1_ID,
+		UBLOXCFG_CFG_MSGOUT_RTCM_3X_TYPE1230_UART1_ID,
+	};
+
+	for (int i = 0; i < (int)(sizeof(rtcm_uart1_ids) / sizeof(rtcm_uart1_ids[0])); i++) {
+		UBLOXCFG_KEYVAL_t* pair = keyValuePairs + length;
+		while (pair --> keyValuePairs) {
+			if (pair->id == rtcm_uart1_ids[i]) {
+				pair->val.U1 = 1;
+				break;
+			}
+		}
+	}
+
+	/* Also enable RTCM3 output protocol on UART1 */
+	UBLOXCFG_KEYVAL_t* pair = keyValuePairs + length;
+	while (pair --> keyValuePairs) {
+		if (pair->id == UBLOXCFG_CFG_UART1OUTPROT_RTCM3X_ID) {
+			pair->val.L = true;
+			break;
+		}
+	}
+
+	log_info("RTCM output enabled in base configuration for comparison");
+	return true;
+}
+
+/**
  * @brief Send configuration from f9_defvalsets.h to GNSS receiver
  *
  * @param rx pointer to serial communication handler
@@ -505,6 +549,7 @@ static bool gnss_set_configuration(RX_t* rx, const struct config* config, int ma
 
 	set_preferred_time_scale(allKvCfg, nAllKvCfg, config);
 	set_cable_delay(allKvCfg, nAllKvCfg, config);
+	set_rtcm_output(allKvCfg, nAllKvCfg, config);
 
 	/* Check if receiver is already configured */
 	receiver_configured = check_gnss_config_in_ram(rx, allKvCfg, nAllKvCfg);


### PR DESCRIPTION
## Fix GNSS receiver reset on every restart when RTCM is enabled

When `gnss-rtcm-enabled=true`, `gnss_set_rtcm_config()` persists RTCM message rates to Flash. On next startup, `check_gnss_config_in_ram()` compares the receiver's current state against the base config which expects RTCM rates = 0. This mismatch triggers a full 571-key reconfiguration + hardware reset every time, causing ~25 minutes of GPS fix loss.

Fix: patch the reference config array to include RTCM rates = 1 before comparison when RTCM is enabled, following the same pattern used by `set_cable_delay()` and `set_preferred_time_scale()`.

### Before

    INFO  Using custom value for "gnss-cable-delay": 672
    DEBUG Config (CFG-MSGOUT-RTCM_3X_TYPE1005_UART1 (0x209102be, U1) = 0) differs from current config (CFG-MSGOUT-RTCM_3X_TYPE1005_UART1 (0x209102be, U1) = 1)
    DEBUG Config (CFG-MSGOUT-RTCM_3X_TYPE1077_UART1 (0x209102cd, U1) = 0) differs from current config (CFG-MSGOUT-RTCM_3X_TYPE1077_UART1 (0x209102cd, U1) = 1)
    DEBUG Config (CFG-MSGOUT-RTCM_3X_TYPE1087_UART1 (0x209102d2, U1) = 0) differs from current config (CFG-MSGOUT-RTCM_3X_TYPE1087_UART1 (0x209102d2, U1) = 1)
    DEBUG Config (CFG-MSGOUT-RTCM_3X_TYPE1097_UART1 (0x20910319, U1) = 0) differs from current config (CFG-MSGOUT-RTCM_3X_TYPE1097_UART1 (0x20910319, U1) = 1)
    DEBUG Config (CFG-MSGOUT-RTCM_3X_TYPE1127_UART1 (0x209102d7, U1) = 0) differs from current config (CFG-MSGOUT-RTCM_3X_TYPE1127_UART1 (0x209102d7, U1) = 1)
    DEBUG Config (CFG-MSGOUT-RTCM_3X_TYPE1230_UART1 (0x20910304, U1) = 0) differs from current config (CFG-MSGOUT-RTCM_3X_TYPE1230_UART1 (0x20910304, U1) = 1)
    INFO  Receiver not configured to desired configuration, starting reconfiguration
    INFO  Configuring receiver with ART parameters...
          rx0: Sending 571 key-value pairs in 10 UBX-CFG-VALSET messages
          ...
    INFO  Successfully reconfigured GNSS receiver
    DEBUG Performing hardware reset
          rx0: Doing receiver reset: Hardware reset
          <GPS fix lost, ~25min recovery>

### After

    INFO  Using custom value for "gnss-cable-delay": 672
    INFO  RTCM output enabled in base configuration for comparison
    INFO  Receiver already configured to desired configuration
          rx0: Sending UBX-CFG-VALSET 1/1 (7 items: 1..7/7, 47 bytes, RAM,BBR,Flash, no transaction)
    INFO  RTCM3 output enabled on UART1 (6 messages configured)
    INFO  RTCM socket listening at /run/oscillatord/rtcm.sock
          <GPS retains fix, 32 satellites, no recovery needed>
