### PR TITLE
ci: install perl dependencies for ubloxcfg

### DIFF
--- a/.github/workflows/build-oscillatord.yaml
+++ b/.github/workflows/build-oscillatord.yaml
@@ -16,6 +16,8 @@ jobs:
       with:
           repository: orolia2s/ubloxcfg
           ref: main
+    - name: Install perl modules for ubloxcfg code-gen
+      run: sudo apt-get update && sudo apt-get install -y libpath-tiny-perl libdata-float-perl
     - name: Compile Ublox configuration shared library
       run: |
         cmake -S . -B build


### PR DESCRIPTION
ubloxcfg_gen.pl needs Path::Tiny (and Data::Float) which aren't on ubuntu-latest. Whether the perl runs at all depends on cmake's timestamp check on the committed generated files, so it's flaky.

With the courtesy of ESoapW