### PR TITLE
sa5x: expose atomic clock firmware version in monitoring output

### DIFF
--- a/src/monitoring.c
+++ b/src/monitoring.c
@@ -559,6 +559,7 @@ static void json_add_oscillator_data(struct json_object *resp, struct monitoring
 
 	struct json_object* oscillator = json_object_new_object();
 	json_object_object_add(oscillator, "model", json_object_new_string(monitoring->oscillator_model));
+	json_object_object_add(oscillator, "fw_version", json_object_new_string(monitoring->osc_attributes.fw_version));
 	json_object_object_add(oscillator, "fine_ctrl", json_object_new_int(monitoring->ctrl_values.fine_ctrl));
 	json_object_object_add(oscillator, "coarse_ctrl", json_object_new_int(monitoring->ctrl_values.coarse_ctrl));
 	json_object_object_add(oscillator, "lock", json_object_new_boolean(monitoring->osc_attributes.locked));
@@ -736,6 +737,7 @@ struct monitoring* monitoring_init(const struct config *config, struct devices_p
 	monitoring->osc_attributes.locked = false;
 	monitoring->osc_attributes.temperature = -400.0;
 	monitoring->osc_attributes.phase_error = 0;
+	monitoring->osc_attributes.fw_version[0] = '\0';
 
 	monitoring->gnss_info.antenna_power = -1;
 	monitoring->gnss_info.antenna_status = -1;

--- a/src/oscillator.h
+++ b/src/oscillator.h
@@ -20,6 +20,10 @@
 #define OSCILLATOR_NAME_LENGTH 50
 #endif
 
+#ifndef OSCILLATOR_FW_VERSION_LENGTH
+#define OSCILLATOR_FW_VERSION_LENGTH 20
+#endif
+
 struct oscillator;
 struct oscillator_ctrl;
 struct oscillator_attributes;
@@ -78,6 +82,8 @@ struct oscillator_attributes {
 	int64_t phase_error;
 	double temperature;
 	bool locked;
+	/* Firmware version of the oscillator, empty string if not reported */
+	char fw_version[OSCILLATOR_FW_VERSION_LENGTH];
 };
 
 int oscillator_get_phase_error(struct oscillator *oscillator, int64_t *phase_error);

--- a/src/oscillators/sa5x_oscillator.c
+++ b/src/oscillators/sa5x_oscillator.c
@@ -637,6 +637,7 @@ static int sa5x_oscillator_get_ctrl(struct oscillator *oscillator, struct oscill
 
 static int sa5x_oscillator_parse_attributes(struct oscillator *oscillator, struct oscillator_attributes *attributes)
 {
+	struct sa5x_oscillator *sa5x = container_of(oscillator, struct sa5x_oscillator, oscillator);
 	struct sa5x_attributes a = {};
 	int err = sa5x_oscillator_get_attributes(oscillator, &a, ATTR_STATUS_TEMPERATURE|ATTR_STATUS_PPS);
 	if (!err) {
@@ -647,6 +648,9 @@ static int sa5x_oscillator_parse_attributes(struct oscillator *oscillator, struc
 		attributes->temperature = -400.0;
 		attributes->locked = 0;
 	}
+	// firmware version is read once at init and cached, propagate it for monitoring
+	strncpy(attributes->fw_version, sa5x->version, sizeof(attributes->fw_version) - 1);
+	attributes->fw_version[sizeof(attributes->fw_version) - 1] = '\0';
 	// we cannot propagate error further
 	return 0;
 }


### PR DESCRIPTION
Propagate the SA5x FW version into oscillator_attributes and add fw_version to the monitoring JSON.

Built with cmake, ran against an SA5x time card, `echo "{}" | nc localhost 2958 | jq .oscillator` shows the correct fw_version

```
  "oscillator": {
    "model": "sa5x",
    "fw_version": "V1.6.5.0.669A7202",
    "fine_ctrl": 75781,
    "coarse_ctrl": 50,
    "lock": true,
    "temperature": 41.57
  }
```